### PR TITLE
add inspirations page design

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,9 +2,9 @@
 
 ## Description
 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+Inspirations page. Shows Inspiring women in tech, women who have dedicated their time to tech. 
 
-Fixes # (issue)
+Fixes #67
 
 ## Type of change
 
@@ -13,7 +13,7 @@ Please delete options that are not relevant.
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
+
 
 ## Checklist:
 


### PR DESCRIPTION

## Description

Adds the inspire screen for Inspiring women in tech 
[](https://www.figma.com/file/kQgBYrI4MWMw3hW3m8GXk0/WIT-INSPIRE?node-id=0%3A1)
![Desktop - 1 (1)](https://user-images.githubusercontent.com/64163022/97528137-3583f400-196a-11eb-9c8b-4146b1ab2523.jpg)



Fixes #67 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected


## Checklist:

- [x] My contribution follows the style guidelines of this project
- [x] I have performed a self-review of my own contribution
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
