### PR TITLE
Fixed 'beginners page' folder structure and content

### DIFF
--- a/website/src/App.js
+++ b/website/src/App.js
@@ -14,6 +14,7 @@ import CommunityPage from "./pages/community";
 import ContributingPage from "./pages/contributing";
 import GithubPage from "./pages/github";
 import EventsPage from "./pages/events";
+import BeginnersPage from "./pages/beginners";
 
 import ScrollButton from "./components/Scroll/ScrollButton";
 
@@ -34,6 +35,7 @@ function App() {
           <Route path="/contributing" exact component={ContributingPage} />
           <Route path="/github" exact component={GithubPage} />
           <Route path="/events" exact component={EventsPage} />
+          <Route path="/beginners" exact component={BeginnersPage} />
         </Switch>
         <Footer />
       </Router>

--- a/website/src/components/BeginnersLinks/BeginnersLinks.css
+++ b/website/src/components/BeginnersLinks/BeginnersLinks.css
@@ -7,6 +7,8 @@
 
 .BeginnersLinks__links {
   display: inline-flex;
+  flex-direction: column;
+  align-items: center;
   width: 100%;
   justify-content: space-evenly;
   margin-bottom: 2rem;
@@ -14,12 +16,14 @@
 
 .BeginnersLinks__github-link, .BeginnersLinks__github-link:hover {
   width: 10rem;
+  height: 4rem;
+  margin: .2rem;
   display: inline-flex;
   align-items: center;
   justify-content: space-evenly;
-  padding: .1rem;
+  padding: .2rem;
   border-radius: 6px;
-  background: #000;
+  background: #111;
   color: #fff;
   text-decoration: none;
   font-weight: bold;
@@ -27,10 +31,25 @@
 
 .BeginnersLinks__open-source-link, .BeginnersLinks__open-source-link:hover {
   width: 10rem;
-  padding: .1rem;
+  height: 4rem;
+  padding: .2rem;
+  margin: .2rem;
   border-radius: 6px;
-  background: #e5e5e5;
-  color: #000;
+  background: #111;
+  color: white;
+  text-decoration: none;
+  text-align: center;
+  font-weight: bold;
+}
+
+.BeginnersLinks__pull-request-link, .BeginnersLinks__pull-request-link:hover {
+  width: 10rem;
+  height: 4rem;
+  padding: .2rem;
+  margin: .2rem;
+  border-radius: 6px;
+  background: #111;
+  color: white;
   text-decoration: none;
   text-align: center;
   font-weight: bold;

--- a/website/src/components/BeginnersLinks/BeginnersLinks.js
+++ b/website/src/components/BeginnersLinks/BeginnersLinks.js
@@ -14,7 +14,6 @@ export default function BeginnersLinks() {
           href="https://github.com/Girlscript-Chapter-Bilaspur/Front-End-Hackathon-Resources/tree/master/Fifth%20Session"
           target="_blank"
           rel="noreferrer noopener"
-          rel="noreferrer"
           className="BeginnersLinks__github-link"
         >
           <img src={githubImage} alt="github link" />
@@ -24,10 +23,17 @@ export default function BeginnersLinks() {
           href="https://opensource.guide/how-to-contribute/"
           target="_blank"
           rel="noreferrer noopener"
-          rel="noreferrer"
           className="BeginnersLinks__open-source-link"
         >
-          Learn How Open Source Work
+          Learn How Open Source Works
+        </a>
+        <a
+          href="https://makeapullrequest.com/"
+          target="_blank"
+          rel="noreferrer noopener"
+          className="BeginnersLinks__pull-request-link"
+        >
+          Learn How To Make Pull Requests
         </a>
       </div>
     </div>

--- a/website/src/components/Header/Header.js
+++ b/website/src/components/Header/Header.js
@@ -129,6 +129,9 @@ export default function Header() {
                 Contribute
               </a>
               <div className="dropdown-menu" aria-labelledby="navbarDropdown">
+              <a className="dropdown-item" href="/beginners">
+                  Beginners
+                </a>
                 <a className="dropdown-item" href="/contributing">
                   Guidelines
                 </a>

--- a/website/src/pages/beginners.js
+++ b/website/src/pages/beginners.js
@@ -1,0 +1,14 @@
+import React from "react";
+
+import BeginnersLinks from "../components/BeginnersLinks/BeginnersLinks";
+import Layout from "../components/Layout";
+
+export default function BeginnersPage() {
+  return (
+    <Layout>
+      <div style={{ height: "3rem", backgroundColor: "#e5e5e5" }} />
+      <BeginnersLinks />
+      {/* <BeginnersLinks /> */}
+    </Layout>
+  );
+}


### PR DESCRIPTION
# Pull Request Template

## Description

I noticed that the 'beginners' page did not appear in the dropdown or even as a valid page in the project when I ran it on my machine, further, there was no proper folder structure followed for it.

I have made the following changes - 
1. Added the page to the dropdown menu
2. Implemented the recommended folder structure for the page and added files where necessary
3. Added a link to https://makeapullrequest.com/ for newcomers on the 'beginners' page
4. Changed the buttons so that they appear in a vertical column to prevent them from getting squashed on mobile

No issue had been opened for this yet.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My contribution follows the style guidelines of this project
- [x] I have performed a self-review of my own contribution
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
